### PR TITLE
PipelineComponentExecutionCompletedInfo timestamp issue

### DIFF
--- a/src/PipelineFramework.Core/AsyncPipeline.cs
+++ b/src/PipelineFramework.Core/AsyncPipeline.cs
@@ -84,8 +84,9 @@ namespace PipelineFramework
                 return await task.ConfigureAwait(false);
             }
 
+            var executionStartingInfo = new PipelineComponentExecutionStartingInfo(component.Name, payload);
             await _componentExecutionStatusReceiver.ReceiveExecutionStartingAsync(
-                    new PipelineComponentExecutionStartingInfo(component.Name, payload))
+                    executionStartingInfo)
                 .ConfigureAwait(false);
 
             var stopwatch = new Stopwatch();
@@ -98,7 +99,7 @@ namespace PipelineFramework
 
                 stopwatch.Stop();
                 await _componentExecutionStatusReceiver.ReceiveExecutionCompletedAsync(
-                        new PipelineComponentExecutionCompletedInfo(component.Name, payload, stopwatch.Elapsed))
+                        new PipelineComponentExecutionCompletedInfo(executionStartingInfo, stopwatch.Elapsed))
                     .ConfigureAwait(false);
 
                 return result;
@@ -107,7 +108,7 @@ namespace PipelineFramework
             {
                 stopwatch.Stop();
                 await _componentExecutionStatusReceiver.ReceiveExecutionCompletedAsync(
-                        new PipelineComponentExecutionCompletedInfo(component.Name, payload, stopwatch.Elapsed, e))
+                        new PipelineComponentExecutionCompletedInfo(executionStartingInfo, stopwatch.Elapsed, e))
                     .ConfigureAwait(false);
 
                 throw;

--- a/src/PipelineFramework.Core/Pipeline.cs
+++ b/src/PipelineFramework.Core/Pipeline.cs
@@ -75,8 +75,9 @@ namespace PipelineFramework
             if (_componentExecutionStatusReceiver == null)
                 return component.Execute(payload, cancellationToken);
 
+            var executionStartingInfo = new PipelineComponentExecutionStartingInfo(component.Name, payload);
             _componentExecutionStatusReceiver.ReceiveExecutionStarting(
-                new PipelineComponentExecutionStartingInfo(component.Name, payload));
+                executionStartingInfo);
             var stopwatch = new Stopwatch();
             stopwatch.Start();
             try
@@ -84,14 +85,14 @@ namespace PipelineFramework
                 var result = component.Execute(payload, cancellationToken);
                 stopwatch.Stop();
                 _componentExecutionStatusReceiver.ReceiveExecutionCompleted(
-                    new PipelineComponentExecutionCompletedInfo(component.Name, payload, stopwatch.Elapsed));
+                    new PipelineComponentExecutionCompletedInfo(executionStartingInfo, stopwatch.Elapsed));
                 return result;
             }
             catch (Exception e)
             {
                 stopwatch.Stop();
                 _componentExecutionStatusReceiver.ReceiveExecutionCompleted(
-                    new PipelineComponentExecutionCompletedInfo(component.Name, payload, stopwatch.Elapsed, e));
+                    new PipelineComponentExecutionCompletedInfo(executionStartingInfo, stopwatch.Elapsed, e));
                 throw;
             }
         }

--- a/src/PipelineFramework.Core/PipelineComponentExecutionCompletedInfo.cs
+++ b/src/PipelineFramework.Core/PipelineComponentExecutionCompletedInfo.cs
@@ -10,26 +10,31 @@ namespace PipelineFramework
     public class PipelineComponentExecutionCompletedInfo : PipelineComponentExecutionStartingInfo
     {
         /// <summary>
-        /// Creates a new instance.
-        /// </summary>
-        /// <param name="pipelineComponentName">Name of the pipeline component that has executed.</param>
-        /// <param name="executionTime">Total amount of execution time for the pipeline component.</param>
-        /// <param name="exception">Exception that might have occurred during pipeline component execution.</param>
-        [Obsolete("Use ctor with 4 parameters instead.")]
-        public PipelineComponentExecutionCompletedInfo(string pipelineComponentName, TimeSpan executionTime, Exception exception = null) 
-            : this(pipelineComponentName, null, executionTime, exception)
-        {
-        }
-
-        /// <summary>
         /// 
         /// </summary>
         /// <param name="pipelineComponentName"></param>
         /// <param name="payload"></param>
         /// <param name="executionTime"></param>
+        /// <param name="startTimeStamp"></param>
         /// <param name="exception"></param>
-        public PipelineComponentExecutionCompletedInfo(string pipelineComponentName, object payload, TimeSpan executionTime, Exception exception = null) 
-            : base(pipelineComponentName, payload)
+        public PipelineComponentExecutionCompletedInfo(string pipelineComponentName, object payload, TimeSpan executionTime, DateTime startTimeStamp, Exception exception = null) 
+            : base(pipelineComponentName, payload, startTimeStamp)
+        {
+            ExecutionTime = executionTime;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// Instantiate a new <see cref="PipelineComponentExecutionCompletedInfo"/> instance
+        /// </summary>
+        /// <param name="startingInfo"></param>
+        /// <param name="executionTime"></param>
+        /// <param name="exception"></param>
+        public PipelineComponentExecutionCompletedInfo(
+            PipelineComponentExecutionStartingInfo startingInfo, 
+            TimeSpan executionTime, 
+            Exception exception = null)
+            : base(startingInfo.PipelineComponentName, startingInfo.Payload, startingInfo.TimeStamp)
         {
             ExecutionTime = executionTime;
             Exception = exception;

--- a/src/PipelineFramework.Core/PipelineComponentExecutionStartingInfo.cs
+++ b/src/PipelineFramework.Core/PipelineComponentExecutionStartingInfo.cs
@@ -24,11 +24,16 @@ namespace PipelineFramework
         /// </summary>
         /// <param name="pipelineComponentName">Name of the pipeline component that has executed.</param>
         /// <param name="payload">Payload used by the executing pipeline.</param>
-        public PipelineComponentExecutionStartingInfo(string pipelineComponentName, object payload)
+        public PipelineComponentExecutionStartingInfo(string pipelineComponentName, object payload) 
+            : this(pipelineComponentName, payload, DateTime.UtcNow)
+        {
+        }
+
+        protected PipelineComponentExecutionStartingInfo(string pipelineComponentName, object payload, DateTime startTimeStamp)
         {
             PipelineComponentName = pipelineComponentName ?? throw new ArgumentNullException(nameof(pipelineComponentName));
             Payload = payload;
-            TimeStamp = DateTime.UtcNow;
+            TimeStamp = startTimeStamp;
         }
 
         /// <summary>

--- a/src/PipelineFramework.Core/PipelineFramework.Core.csproj
+++ b/src/PipelineFramework.Core/PipelineFramework.Core.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/gtmoose32/pipeline-framework</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/gtmoose32/pipeline-framework</RepositoryUrl>
-    <Version>5.0.2</Version>
+    <Version>5.0.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <NeutralLanguage>en</NeutralLanguage>
@@ -19,6 +19,8 @@
     <Product>PipelineFramework.Core</Product>
     <LangVersion>latest</LangVersion>
     <PackageReleaseNotes>
+Changes in v5.0.3
+* BREAKING: Fixed issue with PipelineComponentExecutionCompletedInfo where the timestamp was getting set to the completed time instead of the starting time. This involved a breaking change to the constructor in order to support.
 Changes in v5.0.2
 * Added check for null task returned from AsyncPipelineComponents to prevent NullReferenceException.
 Changes in v5.0.1

--- a/src/PipelineFramework.Extensions.Microsoft.DependencyInjection/PipelineFramework.Extensions.Microsoft.DependencyInjection.csproj
+++ b/src/PipelineFramework.Extensions.Microsoft.DependencyInjection/PipelineFramework.Extensions.Microsoft.DependencyInjection.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/gtmoose32/pipeline-framework</RepositoryUrl>
     <PackageId>PipelineFramework.Extensions.Microsoft.DependencyInjection</PackageId>
     <Product>PipelineFramework.Extensions.Microsoft.DependencyInjection</Product>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <NeutralLanguage>en</NeutralLanguage>
@@ -18,6 +18,8 @@
     <DocumentationFile Condition="'$(Configuration)'=='Release'">bin\Release\netstandard2.1\PipelineFramework.Extensions.Microsoft.DependencyInjection.xml</DocumentationFile>
     <LangVersion>latest</LangVersion>
     <PackageReleaseNotes>
+Changes in v1.1.2
+* Upgraded PipelineFrame.Core dependency to v5.0.3
 Changes in v1.1.1
 * Updated PipelineFramework package dependency version to latest.
 Changes in v1.1.0

--- a/tests/PipelineFramework.Core.Tests/PipelineComponentExecutionCompletedInfoTests.cs
+++ b/tests/PipelineFramework.Core.Tests/PipelineComponentExecutionCompletedInfoTests.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PipelineFramework.TestInfrastructure;
+using System;
+
+namespace PipelineFramework.Core.Tests
+{
+    [TestClass]
+    public class PipelineComponentExecutionCompletedInfoTests
+    {
+        [TestMethod]
+        public void Ctor_SetsPropertiesFromStartingInfo()
+        {
+            // Arrange
+            var startingInfo = new PipelineComponentExecutionStartingInfo("FooComponent", new TestPayload());
+            var executionTime = TimeSpan.FromMilliseconds(100);
+            var exception = new Exception();
+
+            // Act
+            var result = new PipelineComponentExecutionCompletedInfo(startingInfo, executionTime, exception);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.PipelineComponentName.Should().Be(startingInfo.PipelineComponentName);
+            result.Payload.Should().Be(startingInfo.Payload);
+            result.TimeStamp.Should().Be(startingInfo.TimeStamp);
+            result.ExecutionTime.Should().Be(executionTime);
+            result.Exception.Should().Be(exception);
+        }
+    }
+}


### PR DESCRIPTION
Fixing issue with PipelineComponentExecutionCompletedInfo timestamp getting set to end time instead of start time.